### PR TITLE
Replace |FILTER no_break| by |class="nowrap"| for Bugzilla 5.0

### DIFF
--- a/default/attachment/list.html.tmpl
+++ b/default/attachment/list.html.tmpl
@@ -113,7 +113,7 @@ function toggle_display(link) {
                 [% ELSE %]
                   [% flag.setter.nick FILTER html %]:
                 [% END %]
-                [%+ flag.type.name FILTER html FILTER no_break %][% flag.status %]
+                [%+ flag.type.name FILTER html %][% flag.status %]
                 [%+ IF flag.status == "?" && flag.requestee %]
                   [% IF user.id %]
                     (<span title="[% flag.requestee.identity FILTER html %]">[% flag.requestee.nick FILTER html %]</span>)

--- a/default/bug/show-multiple.html.tmpl
+++ b/default/bug/show-multiple.html.tmpl
@@ -259,7 +259,7 @@
                     [% ELSE %]
                       [% FOREACH flag = attachment.flags %]
                         [% flag.setter.nick FILTER html %]:
-                        [%+ flag.type.name FILTER html FILTER no_break %][% flag.status %]
+                        <span class="nowrap">[%+ flag.type.name FILTER html %][% flag.status %]</span>
                         [% IF flag.status == "?" && flag.requestee %]
                           ([% flag.requestee.nick FILTER html %])
                         [% END %][% ", " IF not loop.last() %]
@@ -348,7 +348,7 @@
           [% FOREACH type = bug.flag_types %]
             [% FOREACH flag = type.flags %]
                 [% flag.setter.nick FILTER html %]:
-                [%+ flag.type.name FILTER html FILTER no_break %][% flag.status %]
+                <span class="nowrap">[%+ flag.type.name FILTER html %][% flag.status %]</span>
                 [%+ IF flag.status == "?" && flag.requestee %]
                   ([% flag.requestee.nick FILTER html %])
                 [% END %]<br>

--- a/default/flag/list.html.tmpl
+++ b/default/flag/list.html.tmpl
@@ -76,7 +76,7 @@
       [% ELSE %]
         [% flag.setter.nick FILTER html %]:
       [% END %]
-      [%+ type.name FILTER html FILTER no_break %][% flag.status %]
+      <span class="nowrap">[%+ type.name FILTER html %][% flag.status %]</span>
       [% IF flag.requestee %]
         [% IF flag.requestee.name %]
           (<span title="[% flag.requestee.name FILTER html %]">[% flag.requestee.nick FILTER html %]</span>)
@@ -102,9 +102,9 @@
           [% addl_text FILTER html %]
         [% END %]
       </td>
-      <td>
+      <td class="nowrap">
         <label title="[% type.description FILTER html %]" for="[% fid FILTER html %]">
-          [%- type.name FILTER html FILTER no_break -%]</label>
+          [%- type.name FILTER html %]</label>
       </td>
       <td>
         <input type="hidden" id="[% fid FILTER html %]_dirty">

--- a/default/global/choose-product.html.tmpl
+++ b/default/global/choose-product.html.tmpl
@@ -40,11 +40,11 @@
 
   [% FOREACH p = c.products %]
     <tr>
-      <th align="right" valign="top">
+      <th class="right nowrap" valign="top">
         <a href="[% target %]?product=[% p.name FILTER uri -%]
               [%- IF cloned_bug_id %]&amp;cloned_bug_id=[% cloned_bug_id FILTER uri %][% END -%] 
               [%- IF format %]&amp;format=[% format FILTER uri %][% END %]">
-        [% p.name FILTER html FILTER no_break %]</a>:&nbsp;
+        [% p.name FILTER html %]</a>:&nbsp;
       </th>
 
       <td valign="top">[% p.description FILTER html_light %]</td>

--- a/default/global/useful-links.html.tmpl
+++ b/default/global/useful-links.html.tmpl
@@ -49,7 +49,7 @@
                      [% q.user.id FILTER uri %]"
                class="shared"
                title="Nasdíleno od [% q.user.identity FILTER html %]"
-               >[% q.name FILTER html FILTER no_break %]</a></li>
+               >[% q.name FILTER html %]</a></li>
           [% print_pipe = 1 %]
         [% END %]
       </ul>


### PR DESCRIPTION
Fix of bug https://bugzilla.mozilla.org/show_bug.cgi?id=880282 changed
Bugzilla/Template.pm and has removed no_break filter. Usage
of FILTER no_break was replaced by class="nowrap" as in original English
template in commit 00b1ca6 on https://git.mozilla.org/bugzilla/bugzilla
